### PR TITLE
BuildBot environment preparation

### DIFF
--- a/bin/setup/buildbot/buildPreload.sh
+++ b/bin/setup/buildbot/buildPreload.sh
@@ -17,7 +17,7 @@
 # governing permissions and limitations under the License.
 
 ENV_SRC_DIR="/home/bbadmin/env_BOOSTBULLET"
-BUILDBOT_BUILD_DIR="/home/bbadmin/buildbot/master/build/"
+BUILDBOT_BUILD_DIR="/home/bbadmin/buildbot/slave/master/build"
 
 if [ ! -d $ENV_SRC_DIR ]; then
     echo "Could not find environment source for Bullet and Boost. Searched at ${ENV_SRC_DIR}"


### PR DESCRIPTION
This PR contains a script for preparing our BuildBot build environment. It copies in a pre-compiled copy of Bullet and Boost so builds can finish in a reasonable time.

This script is not very resilient insofar as any changes to Boost or Bullet will cause all subsequent builds to fail. If any changes are made to Boost or Bullet, buildbot's pre-compiled environment directory must be updated manually.
