### PR TITLE
New obstacles and multi-terrain learning

### DIFF
--- a/src/core/terrain/tgHillyGround.cpp
+++ b/src/core/terrain/tgHillyGround.cpp
@@ -85,6 +85,13 @@ tgHillyGround::tgHillyGround(const tgHillyGround::Config& config) :
     pGroundShape = hillyCollisionShape();
 }
 
+tgHillyGround::~tgHillyGround()
+{
+    delete m_pMesh;
+    delete[] m_pIndices;
+    delete[] m_vertices;
+}
+
 btRigidBody* tgHillyGround::getGroundRigidBody() const
 {
         std::cout << "Hilly ground " << std::endl;
@@ -126,26 +133,26 @@ btCollisionShape* tgHillyGround::hillyCollisionShape() {
         const size_t triangleCount = 2 * (m_config.m_nx - 1) * (m_config.m_ny - 1);
 
         // A flattened array of all vertices in the mesh
-        btVector3 * const vertices = new btVector3[vertexCount];
+        m_vertices = new btVector3[vertexCount];
 
         // Supplied by the derived class
-        setVertices(vertices);
+        setVertices(m_vertices);
         // A flattened array of indices for each corner of each triangle
-        int *indices = new int[triangleCount * 3];
+        m_pIndices = new int[triangleCount * 3];
 
         // Supplied by the derived class
-        setIndices(indices);
+        setIndices(m_pIndices);
 
         // Create the mesh object
-        btTriangleIndexVertexArray* const pMesh =
-            createMesh(triangleCount, indices, vertexCount, vertices);
+        m_pMesh = createMesh(triangleCount, m_pIndices, vertexCount, m_vertices);
 
         // Create the shape object
-        pShape = createShape(pMesh);
+        pShape = createShape(m_pMesh);
 
         // Set the margin
         pShape->setMargin(m_config.m_margin);
-        // DO NOT deallocate vertices, indices or pMesh! The shape owns them.
+        // DO NOT deallocate vertices, indices or pMesh until simulation is over!
+        // The shape owns them, but will not delete them
     }
 
     assert(pShape);

--- a/src/core/terrain/tgHillyGround.h
+++ b/src/core/terrain/tgHillyGround.h
@@ -102,8 +102,8 @@ class tgHillyGround : public tgBulletGround
          */
         tgHillyGround(const tgHillyGround::Config& config);
 
-        /** Clean up the implementation. The base class holds nothing. */
-        virtual ~tgHillyGround() { }
+        /** Clean up the implementation. Deletes m_pMesh */
+        virtual ~tgHillyGround();
 
         /**
          * Setup and return a return a rigid body based on the collision 
@@ -140,6 +140,11 @@ class tgHillyGround : public tgBulletGround
          * @param[out] A flattened array of indices in the mesh
          */
         void setIndices(int indices[]);
+        
+        // Store this so we can delete it later
+        btTriangleIndexVertexArray* m_pMesh;
+        btVector3 * m_vertices;
+        int * m_pIndices;
 
 };
 

--- a/src/core/tgSimView.h
+++ b/src/core/tgSimView.h
@@ -56,7 +56,7 @@ public:
           double stepSize = 1.0/1000.0,
           double renderRate = 1.0/60.0);
 
-    ~tgSimView();
+    virtual ~tgSimView();
 
     /**
      * Return a reference to the tgWorld being simulated.

--- a/src/core/tgSimulation.cpp
+++ b/src/core/tgSimulation.cpp
@@ -122,6 +122,24 @@ void tgSimulation::reset()
         m_models[i]->setup(m_view.world());
     }
     
+    // Don't need to set up obstacles since they will be added after this
+}
+
+void tgSimulation::reset(tgGround* newGround)
+{
+
+    teardown();
+    
+    // This will reset the world twice (once in teardown, once here), but that shouldn't hurt anything
+    m_view.world().reset(newGround);
+    
+    m_view.setup();
+    for (std::size_t i = 0; i != m_models.size(); i++)
+    {
+        
+        m_models[i]->setup(m_view.world());
+    }
+    
     // Don't need to set up obstacles since they were just added
 }
 

--- a/src/core/tgSimulation.cpp
+++ b/src/core/tgSimulation.cpp
@@ -199,6 +199,7 @@ void tgSimulation::teardown()
         pModel->teardown();
         
         // Remove and destroy element
+        delete pModel;
         m_obstacles.pop_back();
     }
     

--- a/src/core/tgSimulation.h
+++ b/src/core/tgSimulation.h
@@ -35,6 +35,7 @@ class tgModel;
 class tgModelVisitor;
 class tgSimView;
 class tgWorld;
+class tgGround;
 
 /**
  * Holds objects necessary for simulation, a world, a view
@@ -100,6 +101,15 @@ public:
      * Will delete and remake the dynamics world
      */
     void reset();
+
+    /**
+     * Calls teardown, then sets the ground of the world to newGround
+     * then calls setup on the view, finally
+     * calls setup on the models
+     * Will delete and remake the dynamics world, the previous
+     * ground will be deleted
+     */
+    void reset(tgGround* newGround);
     
     /**
      * Returns a reference to the world

--- a/src/dev/btietz/CMakeLists.txt
+++ b/src/dev/btietz/CMakeLists.txt
@@ -21,4 +21,5 @@ subdirs(
     kinematicString
     GATests
     Obstacles
+    multiTerrain
     )

--- a/src/dev/btietz/Obstacles/AppObstacleTest.cpp
+++ b/src/dev/btietz/Obstacles/AppObstacleTest.cpp
@@ -82,7 +82,7 @@ int main(int argc, char** argv)
 	// Second create the view
 	const double timestep_physics = 1.0/1000.0; // seconds
 	const double timestep_graphics = 1.f/60.f; // seconds
-	tgSimViewGraphics view(world, timestep_physics, timestep_graphics);
+	tgSimView view(world, timestep_physics, timestep_graphics);
 	
 	// Third create the simulation
 	tgSimulation simulation(view);
@@ -108,16 +108,13 @@ int main(int argc, char** argv)
         {
             // World will delete prior pointer, so make a new one each time
             tgHillyGround* hillGround = new tgHillyGround(hillGroundConfig);
-            world.reset(hillGround);
+            simulation.reset(hillGround);
         }
         else
         {
             ground = new tgBoxGround(groundConfig);
-            world.reset(ground);
-        }
-        
-        simulation.reset();
-        
+            simulation.reset(ground);
+        }        
     }
 	return 0;
 }

--- a/src/dev/btietz/TCContact/CMakeLists.txt
+++ b/src/dev/btietz/TCContact/CMakeLists.txt
@@ -13,6 +13,10 @@ link_libraries(CPG_feedback
                 AnnealEvolution
                 tgOpenGLSupport)
 
+add_library(flemonsSpineContact 
+                FlemonsSpineModelContact.cpp
+            )
+                
 add_executable(AppFlemonsSpineContact
     FlemonsSpineModelContact.cpp
     AppFlemonsSpineContact.cpp

--- a/src/dev/btietz/multiTerrain/AppMultiTerrain.cpp
+++ b/src/dev/btietz/multiTerrain/AppMultiTerrain.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2012, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ * 
+ * The NASA Tensegrity Robotics Toolkit (NTRT) v1 platform is licensed
+ * under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+*/
+
+/**
+ * @file AppMultiTerrain.cpp
+ * @brief Contains the definition of functions for multi-terrain app
+ * @author Brian Mirletz, Alexander Xydes
+ * @copyright Copyright (C) 2014 NASA Ames Research Center
+ * $Id$
+ */
+
+#include "AppMultiTerrain.h"
+
+AppMultiTerrain::AppMultiTerrain(int argc, char** argv)
+{
+    bSetup = false;
+    use_graphics = true;
+    add_controller = false;
+    add_duct = false;
+    timestep_physics = 1.0f/60.0f/10.0f;
+    timestep_graphics = 1.0f/60.0f;
+    nEpisodes = 1;
+    nSteps = 60000;
+
+    startX = 0;
+    startY = 20;
+    startZ = 0;
+    startRotX = 0;
+    startRotY = 0;
+    startRotZ = 0;
+    startAngle = 0;
+    targetDist = -1;
+
+    handleOptions(argc, argv);
+}
+
+bool AppMultiTerrain::setup()
+{
+    // First create the world
+    tgWorld* world = createWorld();
+
+    // Second create the view
+    tgSimView *view;
+    if (use_graphics)
+        view = createGraphicsView(world); // For visual experimenting on one tensegrity
+    else
+        view = createView(world);         // For running multiple episodes
+
+    // Third create the simulation
+    simulation = new tgSimulation(*view);
+
+    // Fourth create the models with their controllers and add the models to the
+    // simulation
+    DuCTTRobotModel::Config c = DuCTTRobotModel::Config(
+                btVector3(startX,startY,startZ),
+                btVector3(startRotX,startRotY,startRotZ),
+                (startAngle*SIMD_RADS_PER_DEG)
+                );
+    DuCTTRobotModel* myRobotModel = new DuCTTRobotModel(c);
+
+    // Fifth create the controllers, attach to model
+    if (add_controller)
+    {
+        DuCTTSineWaves* const pPrismControl = new DuCTTSineWaves(targetDist);
+        myRobotModel->attach(pPrismControl);
+    }
+
+    // Sixth add model & controller to simulation
+    simulation->addModel(myRobotModel);
+
+    // Seventh add duct to simulation
+    if (add_duct)
+    {
+        DuctStraightModel::Config ductConfig;
+        ductConfig.m_ductWidth = 45;
+        ductConfig.m_ductHeight = 45;
+        ductConfig.m_distance = 1000;
+        ductConfig.m_axis = 2;
+        ductConfig.m_startPos = btVector3(0,0,-100);
+        DuctStraightModel* myDuctModel = new DuctStraightModel(ductConfig);
+        simulation->addModel(myDuctModel);
+
+//        DuctCrossModel* myDuctModel = new DuctCrossModel();
+//        simulation->addModel(myDuctModel);
+
+//        DuctTeeModel* myDuctModel = new DuctTeeModel();
+//        simulation->addModel(myDuctModel);
+
+//        DuctLModel* myDuctModel = new DuctLModel();
+//        simulation->addModel(myDuctModel);
+    }
+
+    bSetup = true;
+    return bSetup;
+}
+
+void AppMultiTerrain::handleOptions(int argc, char **argv)
+{
+    // Declare the supported options.
+    po::options_description desc("Allowed options");
+    desc.add_options()
+        ("help,h", "produce help message")
+        ("graphics,G", po::value<bool>(&use_graphics), "Test using graphical view")
+        ("controller,c", po::value<bool>(&add_controller)->implicit_value(true), "Attach the controller to the model.")
+        ("duct,d", po::value<bool>(&add_duct)->implicit_value(true), "Add the duct to the simulation.")
+        ("phys_time,p", po::value<double>(), "Physics timestep value (Hz). Default=1000")
+        ("graph_time,g", po::value<double>(), "Graphics timestep value a.k.a. render rate (Hz). Default = 60")
+        ("episodes,e", po::value<int>(&nEpisodes), "Number of episodes to run. Default=1")
+        ("steps,s", po::value<int>(&nSteps), "Number of steps per episode to run. Default=60K (100 seconds)")
+        ("start_x,x", po::value<double>(&startX), "X Coordinate of starting position for robot. Default = 0")
+        ("start_y,y", po::value<double>(&startY), "Y Coordinate of starting position for robot. Default = 20")
+        ("start_z,z", po::value<double>(&startZ), "Z Coordinate of starting position for robot. Default = 0")
+        ("rot_x", po::value<double>(&startRotX), "X Coordinate of starting rotation axis for robot. Default = 0")
+        //Can only support rotation around the x axis for now.
+//        ("rot_y", po::value<double>(&startRotY), "Y Coordinate of starting rotation axis for robot. Default = 0")
+//        ("rot_z", po::value<double>(&startRotZ), "Z Coordinate of starting rotation axis for robot. Default = 0")
+        ("angle,a", po::value<double>(&startAngle), "Angle of starting rotation for robot. Degrees. Default = 0")
+        ("target_dist,t", po::value<double>(&targetDist), "Target distance for controller to move robot. Default = infinite")
+    ;
+
+    po::variables_map vm;
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+
+    if (vm.count("help"))
+    {
+        std::cout << desc << "\n";
+        exit(0);
+    }
+
+    po::notify(vm);
+
+    if (vm.count("phys_time"))
+    {
+        timestep_physics = 1/vm["phys_time"].as<double>();
+        std::cout << "Physics timestep set to: " << timestep_physics << " seconds.\n";
+    }
+
+    if (vm.count("graph_time"))
+    {
+        timestep_graphics = 1/vm["graph_time"].as<double>();
+        std::cout << "Graphics timestep set to: " << timestep_graphics << " seconds.\n";
+    }
+}
+
+tgWorld* AppMultiTerrain::createWorld()
+{
+    const tgWorld::Config config(
+        981 // gravity, cm/sec^2
+    );
+
+    return new tgWorld(config);
+}
+
+tgSimViewGraphics *AppMultiTerrain::createGraphicsView(tgWorld *world)
+{
+    return new tgSimViewGraphics(*world, timestep_physics, timestep_graphics);
+}
+
+tgSimView *AppMultiTerrain::createView(tgWorld *world)
+{
+    return new tgSimView(*world, timestep_physics, timestep_graphics);
+}
+
+bool AppMultiTerrain::run()
+{
+    if (!bSetup)
+    {
+        setup();
+    }
+
+    if (use_graphics)
+    {
+        // Run until the user stops
+        simulation->run();
+    }
+    else
+    {
+        // or run for a specific number of steps
+        simulate(simulation);
+    }
+
+    return true;
+}
+
+void AppMultiTerrain::simulate(tgSimulation *simulation)
+{
+    for (int i=0; i<nEpisodes; i++) {
+        fprintf(stderr,"Episode %d\n", i);
+        simulation->run(nSteps);
+        simulation->reset();
+    }
+}
+
+/**
+ * The entry point.
+ * @param[in] argc the number of command-line arguments
+ * @param[in] argv argv[0] is the executable name
+ * @return 0
+ */
+int main(int argc, char** argv)
+{
+    std::cout << "AppMultiTerrain" << std::endl;
+    AppMultiTerrain app (argc, argv);
+
+    if (app.setup())
+        app.run();
+    
+    delete simulation;
+    //Teardown is handled by delete, so that should be automatic
+    return 0;
+}
+

--- a/src/dev/btietz/multiTerrain/AppMultiTerrain.cpp
+++ b/src/dev/btietz/multiTerrain/AppMultiTerrain.cpp
@@ -54,10 +54,9 @@ AppMultiTerrain::AppMultiTerrain(int argc, char** argv)
 bool AppMultiTerrain::setup()
 {
     // First create the world
-    tgWorld* world = createWorld();
+    world = createWorld();
 
     // Second create the view
-    tgSimView *view;
     if (use_graphics)
         view = createGraphicsView(world); // For visual experimenting on one tensegrity
     else
@@ -126,6 +125,7 @@ bool AppMultiTerrain::setup()
                                                     pfMin,
                                                     pfMax
                                                     );
+        /// @todo fix memory leak that occurs here
         SpineFeedbackControl* const myControl =
         new SpineFeedbackControl(control_config, suffix, "bmirletz/TetrahedralComplex_Contact/");
         myModel->attach(myControl);;
@@ -277,7 +277,12 @@ bool AppMultiTerrain::run()
         // or run for a specific number of steps
         simulate(simulation);
     }
-
+    
+    ///@todo consider app.cleanup()
+   delete simulation;
+   delete view;
+   delete world;
+    
     return true;
 }
 
@@ -287,7 +292,8 @@ void AppMultiTerrain::simulate(tgSimulation *simulation)
         fprintf(stderr,"Episode %d\n", i);
         simulation->run(nSteps);
         
-        if (all_terrain)
+        // Don't change the terrain before the last episode to avoid leaks
+        if (all_terrain && i != nEpisodes - 1)
         {   
             // Next run has Hills
             if (i % nTypes == 0)

--- a/src/dev/btietz/multiTerrain/AppMultiTerrain.h
+++ b/src/dev/btietz/multiTerrain/AppMultiTerrain.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2012, United States Government, as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All rights reserved.
+ * 
+ * The NASA Tensegrity Robotics Toolkit (NTRT) v1 platform is licensed
+ * under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+*/
+
+#ifndef APP_MULTI_TERRAIN
+#define APP_MULTI_TERRAIN
+
+/**
+ * @file AppMultiTerrain.cpp
+ * @brief Contains the definition function main() for the Multiple terrains app
+ * @author Brian Mirletz, Alexander Xydes
+ * $Id$
+ */
+
+//robot
+#include "robot/DuCTTRobotModel.h"
+
+//ducts
+#include "ducts/DuctCrossModel.h"
+#include "ducts/DuctLModel.h"
+#include "ducts/DuctStraightModel.h"
+#include "ducts/DuctTeeModel.h"
+
+//controllers
+#include "controllers/DuCTTSineWaves.h"
+
+// This library
+#include "core/tgModel.h"
+#include "core/tgSimViewGraphics.h"
+#include "core/tgSimulation.h"
+#include "core/tgWorld.h"
+
+// Boost
+#include <boost/program_options.hpp>
+
+// The C++ Standard Library
+#include <iostream>
+
+namespace po = boost::program_options;
+
+class AppMultiTerrain
+{
+public:
+    AppMultiTerrain(int argc, char** argv);
+
+    /** Setup the simulation */
+    bool setup();
+    /** Run the simulation */
+    bool run();
+
+private:
+    /** Parse command line options */
+    void handleOptions(int argc, char** argv);
+
+    /** Create the tgWorld object */
+    tgWorld *createWorld();
+
+    /** Use for displaying tensegrities in simulation */
+    tgSimViewGraphics *createGraphicsView(tgWorld *world);
+
+    /** Use for trial episodes of many tensegrities in an experiment */
+    tgSimView *createView(tgWorld *world);
+
+    /** Run a series of episodes for nSteps each */
+    void simulate(tgSimulation *simulation);
+
+    tgSimulation* simulation;
+
+    bool use_graphics;
+    bool add_controller;
+    bool add_duct;
+    double timestep_physics; //Seconds
+    double timestep_graphics; // Seconds, AKA render rate. Leave at 1/60 for real-time viewing
+    int nEpisodes; // Number of episodes ("trial runs")
+    int nSteps; // Number of steps in each episode, 60k is 100 seconds (timestep_physics*nSteps)
+
+    double startX;
+    double startY;
+    double startZ;
+    double startRotX;
+    double startRotY;
+    double startRotZ;
+    double startAngle;
+
+    double targetDist;
+
+    bool bSetup;
+};
+
+#endif  // APP_DUCTT

--- a/src/dev/btietz/multiTerrain/AppMultiTerrain.h
+++ b/src/dev/btietz/multiTerrain/AppMultiTerrain.h
@@ -32,6 +32,9 @@
 // controller 
 #include "dev/CPG_feedback/SpineFeedbackControl.h"
 
+// obstacles
+#include "dev/btietz/Obstacles/tgBlockField.h"
+
 // This library
 #include "core/tgModel.h"
 #include "core/tgSimViewGraphics.h"
@@ -67,6 +70,8 @@ private:
     
     const tgBoxGround::Config getBoxConfig();
     
+    tgModel* getBlocks();
+    
     /** Create the tgWorld object */
     tgWorld *createWorld();
 
@@ -91,6 +96,7 @@ private:
     int nEpisodes; // Number of episodes ("trial runs")
     int nSteps; // Number of steps in each episode, 60k is 100 seconds (timestep_physics*nSteps)
     int nSegments; // Number of segments in the tensegrity spine
+    int nTypes; // Number of types of terrain to be used. Currently 3
 
     double startX;
     double startY;

--- a/src/dev/btietz/multiTerrain/AppMultiTerrain.h
+++ b/src/dev/btietz/multiTerrain/AppMultiTerrain.h
@@ -27,28 +27,25 @@
  */
 
 //robot
-#include "robot/DuCTTRobotModel.h"
+#include "dev/btietz/TCContact/FlemonsSpineModelContact.h"
 
-//ducts
-#include "ducts/DuctCrossModel.h"
-#include "ducts/DuctLModel.h"
-#include "ducts/DuctStraightModel.h"
-#include "ducts/DuctTeeModel.h"
-
-//controllers
-#include "controllers/DuCTTSineWaves.h"
+// controller 
+#include "dev/CPG_feedback/SpineFeedbackControl.h"
 
 // This library
 #include "core/tgModel.h"
 #include "core/tgSimViewGraphics.h"
 #include "core/tgSimulation.h"
 #include "core/tgWorld.h"
+#include "core/terrain/tgBoxGround.h"
+#include "core/terrain/tgHillyGround.h"
 
 // Boost
 #include <boost/program_options.hpp>
 
 // The C++ Standard Library
 #include <iostream>
+#include <string>
 
 namespace po = boost::program_options;
 
@@ -66,6 +63,10 @@ private:
     /** Parse command line options */
     void handleOptions(int argc, char** argv);
 
+    const tgHillyGround::Config getHillyConfig();
+    
+    const tgBoxGround::Config getBoxConfig();
+    
     /** Create the tgWorld object */
     tgWorld *createWorld();
 
@@ -77,27 +78,27 @@ private:
 
     /** Run a series of episodes for nSteps each */
     void simulate(tgSimulation *simulation);
-
+    
     tgSimulation* simulation;
 
     bool use_graphics;
     bool add_controller;
-    bool add_duct;
+    bool add_blocks;
+    bool add_hills;
+    bool all_terrain;
     double timestep_physics; //Seconds
     double timestep_graphics; // Seconds, AKA render rate. Leave at 1/60 for real-time viewing
     int nEpisodes; // Number of episodes ("trial runs")
     int nSteps; // Number of steps in each episode, 60k is 100 seconds (timestep_physics*nSteps)
+    int nSegments; // Number of segments in the tensegrity spine
 
     double startX;
     double startY;
     double startZ;
-    double startRotX;
-    double startRotY;
-    double startRotZ;
     double startAngle;
-
-    double targetDist;
-
+    
+    std::string suffix;
+    
     bool bSetup;
 };
 

--- a/src/dev/btietz/multiTerrain/AppMultiTerrain.h
+++ b/src/dev/btietz/multiTerrain/AppMultiTerrain.h
@@ -84,6 +84,10 @@ private:
     /** Run a series of episodes for nSteps each */
     void simulate(tgSimulation *simulation);
     
+    
+    // Keep these around for cleanup
+    tgWorld* world;
+    tgSimView* view;
     tgSimulation* simulation;
 
     bool use_graphics;

--- a/src/dev/btietz/multiTerrain/CMakeLists.txt
+++ b/src/dev/btietz/multiTerrain/CMakeLists.txt
@@ -1,0 +1,5 @@
+link_libraries(obstacles tgcreator core controllers boost_program_options)
+
+add_executable(AppMultiTerrain
+    AppMultiTerrain.cpp
+)

--- a/src/dev/btietz/multiTerrain/CMakeLists.txt
+++ b/src/dev/btietz/multiTerrain/CMakeLists.txt
@@ -1,4 +1,19 @@
-link_libraries(obstacles tgcreator core controllers boost_program_options)
+link_libraries(obstacles
+               flemonsSpineContact
+               CPG_feedback
+                KinematicString
+                learningSpines
+                sensors
+                controllers
+                tgcreator             
+                core
+                util
+                terrain
+                Adapters
+                Configuration
+                AnnealEvolution
+                tgOpenGLSupport
+                boost_program_options)
 
 add_executable(AppMultiTerrain
     AppMultiTerrain.cpp


### PR DESCRIPTION
This pull request introduces two new obstacles - a randomized block field and stairs, and implements features that allow for learning on multiple terrains. These include:

1) The introduction of obstacles as a tgModel type, which are deleted at the end of a simulation. (#125)

2) The ability to change the ground used by the world as an option for tgSimulation.reset(tgGround*)

3) An adaptation of DuCTT main that implements these features.

Testing an existing controller, I got the following results: https://gist.github.com/brtietz/2d73343ba243fe2d19a8

Note that the world gets reset twice, hence the double print statements about the type of terrain - this doesn't appear to cause any problems since the models haven't been setup yet. That controller happens to do well on the hilly terrain but very poorly on the blocks.

I'd like to get #122 with this merge as well so all of the obstacles are in core, but I need some feedback on where to place the obstacles library. I'd also apprecaite thoughts on whether or not to leave in the print statements that are used when the ground is initialized.