### PR TITLE
Download URLs now point to self-hosted dependencies.

### DIFF
--- a/conf/default/boost.conf.default
+++ b/conf/default/boost.conf.default
@@ -39,4 +39,4 @@ BOOST_PACKAGE_DIR="$BOOST_BUILD_DIR"
 
 # BOOST_URL can be either a web address or a local file address,
 # e.g. http://url.com/for/boost.tgz or file:///path/to/boost.tgz
-BOOST_URL="http://sourceforge.net/projects/boost/files/boost/1.53.0/boost_1_53_0.tar.gz"
+BOOST_URL="http://storage.perryb.ca/ntrt/dependencies/boost_1_53_0.tar.gz"

--- a/conf/default/bullet.conf.default
+++ b/conf/default/bullet.conf.default
@@ -40,4 +40,4 @@ BULLET_PACKAGE_DIR="$BULLET_BUILD_DIR"
 
 # BULLET_URL can be either a web address or a local file address, 
 # e.g. 'http://url.com/for/bullet.tgz' or 'file:///path/to/bullet.tgz'
-BULLET_URL="http://bullet.googlecode.com/files/bullet-2.82-r2704.tgz"
+BULLET_URL="http://storage.perryb.ca/ntrt/dependencies/bullet-2.82-r2704.tgz"

--- a/conf/default/gmocktest.conf.default
+++ b/conf/default/gmocktest.conf.default
@@ -39,4 +39,4 @@ GMOCKTEST_PACKAGE_DIR="$GMOCKTEST_BUILD_DIR"
 
 # GMOCKTEST_URL can be either a web address or a local file address,
 # e.g. http://url.com/for/gmocktest.tgz or file:///path/to/gmocktest.tgz
-GMOCKTEST_URL="https://googlemock.googlecode.com/files/gmock-1.7.0.zip"
+GMOCKTEST_URL="http://storage.perryb.ca/ntrt/dependencies/gmock-1.7.0.zip"

--- a/conf/default/jsoncpp.conf.default
+++ b/conf/default/jsoncpp.conf.default
@@ -39,4 +39,4 @@ JSONCPP_PACKAGE_DIR="$JSONCPP_BUILD_DIR"
 
 # JSONCPP_URL can be either a web address or a local file address,
 # e.g. http://url.com/for/jsoncpp.tgz or file:///path/to/jsoncpp.tgz
-JSONCPP_URL="https://github.com/open-source-parsers/jsoncpp/archive/f1642886464e75dbb0d3b89a9fe578238fef5273.zip"
+JSONCPP_URL="http://storage.perryb.ca/ntrt/dependencies/jsoncpp_1.6.zip"

--- a/conf/default/neuralnet.conf.default
+++ b/conf/default/neuralnet.conf.default
@@ -40,4 +40,4 @@ NEURALNET_BUILD_DIR="$NEURALNET_PACKAGE_DIR/nnImplementationV2/Neural Network v2
 
 # NEURALNET_URL can be either a web address or a local file address,
 # e.g. http://url.com/for/jsoncpp.tgz or file:///path/to/jsoncpp.tgz
-NEURALNET_URL="http://dl.dropbox.com/u/18209754/Blog/nnImplementationV2.zip"
+NEURALNET_URL="http://storage.perryb.ca/ntrt/dependencies/nnImplementationV2.zip"

--- a/conf/default/virtualenv.conf.default
+++ b/conf/default/virtualenv.conf.default
@@ -45,7 +45,7 @@ VENV_PACKAGE_DIR="$VENV_BUILD_DIR"
 
 # *_URL can be either a web address or a local file address,
 # e.g. http://url.com/for/package.tgz or file:///path/to/package.tgz
-VENV_URL="https://pypi.python.org/packages/source/v/virtualenv/virtualenv-1.9.tar.gz"
+VENV_URL="http://storage.perryb.ca/ntrt/dependencies/virtualenv-1.9.tar.gz"
 
 # Path to python interpreter to use for setting up the virtualenv
 VENV_PYTHON_INTERPRETER="/usr/bin/python2.7"


### PR DESCRIPTION
This PR contains changes to all dependency URLs so they're self-hosted.

I'll hold off on merging this for a day or two to ensure no one objects.

More details/justification for the changes can be found in issue 145.