### PR TITLE
Update neural net patches for platform independence

### DIFF
--- a/bin/setup/patches/neuralNet/NNPatch2_1.patch
+++ b/bin/setup/patches/neuralNet/NNPatch2_1.patch
@@ -1,5 +1,5 @@
---- "NTRTmaster/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.cpp"	2014-10-03 15:14:25.618566584 -0400
-+++ "NTRTTests/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.cpp"	2015-01-07 13:12:33.331713575 -0500
+--- NTRTmaster/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.cpp	2014-10-03 15:14:25.618566584 -0400
++++ NTRTTests/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.cpp	2015-01-07 13:12:33.331713575 -0500
 @@ -4,6 +4,7 @@
  #include <fstream>
  #include <math.h>

--- a/bin/setup/patches/neuralNet/NNPatch2_2.patch
+++ b/bin/setup/patches/neuralNet/NNPatch2_2.patch
@@ -1,5 +1,5 @@
---- "NTRTmaster/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.h"	2014-10-03 15:14:25.618566584 -0400
-+++ "NTRTTests/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.h"	2015-01-07 13:26:26.291748108 -0500
+--- NTRTmaster/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.h	2014-10-03 15:14:25.618566584 -0400
++++ NTRTTests/env/build/neuralNet/nnImplementationV2/Neural Network v2/neuralNetwork.h	2015-01-07 13:26:26.291748108 -0500
 @@ -17,7 +17,7 @@
  {
  	//class members

--- a/bin/setup/setup_jsoncpp.sh
+++ b/bin/setup/setup_jsoncpp.sh
@@ -118,6 +118,11 @@ function build_jsoncpp()
         -DCMAKE_INSTALL_PREFIX="$JSONCPP_INSTALL_PREFIX" \
         -DCMAKE_C_COMPILER="gcc" \
         -DCMAKE_CXX_COMPILER="g++" \
+        -DCMAKE_C_FLAGS="-fPIC" \
+        -DCMAKE_CXX_FLAGS="-fPIC" \
+        -DCMAKE_EXE_LINKER_FLAGS="-fPIC" \
+        -DCMAKE_MODULE_LINKER_FLAGS="-fPIC" \
+        -DCMAKE_SHARED_LINKER_FLAGS="-fPIC" \
         -DUSE_DOUBLE_PRECISION=OFF \
         -DCMAKE_INSTALL_NAME_DIR="$JSONCPP_INSTALL_PREFIX" || { echo "- ERROR: CMake for JsonCPP failed."; exit 1; }
     #If you turn this on, turn it on in inc.CMakeJsonCPP.txt as well for the NTRT build

--- a/bin/setup/setup_jsoncpp.sh
+++ b/bin/setup/setup_jsoncpp.sh
@@ -118,11 +118,6 @@ function build_jsoncpp()
         -DCMAKE_INSTALL_PREFIX="$JSONCPP_INSTALL_PREFIX" \
         -DCMAKE_C_COMPILER="gcc" \
         -DCMAKE_CXX_COMPILER="g++" \
-        -DCMAKE_C_FLAGS="-fPIC" \
-        -DCMAKE_CXX_FLAGS="-fPIC" \
-        -DCMAKE_EXE_LINKER_FLAGS="-fPIC" \
-        -DCMAKE_MODULE_LINKER_FLAGS="-fPIC" \
-        -DCMAKE_SHARED_LINKER_FLAGS="-fPIC" \
         -DUSE_DOUBLE_PRECISION=OFF \
         -DCMAKE_INSTALL_NAME_DIR="$JSONCPP_INSTALL_PREFIX" || { echo "- ERROR: CMake for JsonCPP failed."; exit 1; }
     #If you turn this on, turn it on in inc.CMakeJsonCPP.txt as well for the NTRT build


### PR DESCRIPTION
I finally started seeing the issues originally reported in #139 on a linux box, so I took the recommendations from Bob Montgomery on the NTRT User's list and removed the double quotes for platform independence. This also includes some experiments with the JSON build, but should be identical to master now.