### PR TITLE
Fix libs for spine test

### DIFF
--- a/src/examples/contactCables/AppContactCables.cpp
+++ b/src/examples/contactCables/AppContactCables.cpp
@@ -58,7 +58,7 @@ int main(int argc, char** argv)
 	// Second create the view
 	const double timestep_physics = 1.0/500.0; // seconds
 	const double timestep_graphics = 1.f/120.f; // seconds
-	tgSimView view(world, timestep_physics, timestep_graphics);
+	tgSimViewGraphics view(world, timestep_physics, timestep_graphics);
 	
 	// Third create the simulation
 	tgSimulation simulation(view);

--- a/src/examples/contactCables/ContactCableDemo.cpp
+++ b/src/examples/contactCables/ContactCableDemo.cpp
@@ -58,26 +58,22 @@ void ContactCableDemo::setup(tgWorld& world)
 	
 	tgStructure s;
 	
-	s.addNode(-2, 2, 0);
-	s.addNode(0, 2, 0);
-	s.addNode(0, 2, 0);
-	s.addNode(0, 4, 0);
-	s.addNode(0, 12, 0);
-	s.addNode(0, 14, 0);
+	s.addNode(0, 2, 0); // 0
+	s.addNode(0, 4, 0); // 1
+	s.addNode(0, 12, 0); // 2
+	s.addNode(0, 14, 0); // 3
 	
 	
-	// Free rod to which we will apply motion
-	s.addNode(-1, 6, 5);
-	s.addNode(1, 6, 5);
+	// Static rod that the others will run into
+	s.addNode(-1, 8, 5); // 4
+	s.addNode(1, 8, 5); // 5
 
-	//s.addPair(0, 1, "rod");
+	s.addPair(0, 1, "rod");
 	s.addPair(2, 3, "box");
-	s.addPair(4, 5, "box");
 	
-	s.addPair(6, 7, "rod");
+	s.addPair(4, 5, "rod");
 
-	//s.addPair(1, 2, "muscle");
-	s.addPair(3, 4, "muscle");
+	s.addPair(1, 2, "muscle");
 	s.move(btVector3(0, 0, 0));
 
 
@@ -109,7 +105,7 @@ void ContactCableDemo::setup(tgWorld& world)
 	btRigidBody* body2 = allRods[1]->getPRigidBody();
 	
 	// Apply initial impulse
-	btVector3 impulse(0.5, 0.0, 0.5);
+	btVector3 impulse(0.4, 0.0, 0.4);
 	body->applyCentralImpulse(impulse);
 	body2->applyCentralImpulse(impulse);
 	

--- a/test_integration/CMakeLists.txt
+++ b/test_integration/CMakeLists.txt
@@ -37,8 +37,7 @@ link_directories(${ENV_LIB_DIR} ${OPENGL_LIB} ${OPENGL_FG_LIB})
 subdirs(
  ICRA2015Tests
  MuscleNP
- # SpineTests * Test has been disabled. See BuildBot build 494 for the error details. See issue #200 (https://github.com/NASA-Tensegrity-Robotics-Toolkit/NTRTsim/issues/200 -- Perry
- 
+ SpineTests
  TimestepIndependence
  #HillTest // * Test has been disabled. See BuildBot build 335 for the error details. See issue #163 (https://github.com/NASA-Tensegrity-Robotics-Toolkit/NTRTsim/issues/163 -- Perry
  

--- a/test_integration/SpineTests/CMakeLists.txt
+++ b/test_integration/SpineTests/CMakeLists.txt
@@ -9,6 +9,5 @@ add_executable(WorldConf_Spines_test
 target_link_libraries(WorldConf_Spines_test ${ENV_LIB_DIR}/libgtest.a pthread 
 												${NTRT_BUILD_DIR}/core/libcore.so 
 												${NTRT_BUILD_DIR}/helpers/libFileHelpers.so 
-												${NTRT_BUILD_DIR}/examples/learningSpines/liblearningSpines.so 
-												${NTRT_BUILD_DIR}/dev/btietz/kinematicString/libKinematicString.so 
+												${NTRT_BUILD_DIR}/examples/learningSpines/liblearningSpines.so
 												${NTRT_BUILD_DIR}/examples/learningSpines/TetrahedralComplex/libTetrahedralComplex.so)


### PR DESCRIPTION
Changes to cmake lists and collision cable examples to make the integration tests pass. Fixes #200 and #201 